### PR TITLE
Add support for light effects

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -38,7 +38,20 @@ else
     body="{\"color\":\"${color}\",\"power\":\"on\"}"
 fi
 
+# check whether to employ an effect instead of just turning it a solid color
+if [[ "${effect}" != "none" ]]; then
+    endpoint="lights/label:${bulb_label}/effects/${effect}"
+    body="{\"color\":\"${color}\",\"from_color\":\"white\",\"cycles\":10}"
+    method="POST"
+else
+    endpoint="lights/label:${bulb_label}/state"
+    method="PUT"
+fi
+
 # change bulb color via API
-curl -s -X PUT -H "Content-Type: application/json" -H "Authorization: Bearer ${auth_token}" -d ${body} "https://api.lifx.com/v1/lights/label:${bulb_label}/state" #> /dev/null
+curl -s -X $method \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer ${auth_token}" \
+    -d ${body} "https://api.lifx.com/v1/$endpoint" #> /dev/null
 return_code=$?
 exit ${return_code}

--- a/step.yml
+++ b/step.yml
@@ -81,7 +81,7 @@ inputs:
       description: |
         If custom color provided, it will be used instead of LIFX default.
         Format RRGGBB, e.g: ff0000 (red).
-  - effect: "None"
+  - effect: "none"
     opts:
       title: "Effect"
       description: |

--- a/step.yml
+++ b/step.yml
@@ -81,3 +81,12 @@ inputs:
       description: |
         If custom color provided, it will be used instead of LIFX default.
         Format RRGGBB, e.g: ff0000 (red).
+  - effect: "None"
+    opts:
+      title: "Effect"
+      description: |
+        Instead of setting a solid color, do you want to e.g. pulse the light?
+      value_options:
+        - "none"
+        - "pulse"
+        - "breathe"


### PR DESCRIPTION
This will allow users to add an effect like pulsing/breathing instead of just turning a solid color. I long for more attention when seeing a new build pass/fail 🤣 Parameters for effects are not configurable except for the color. The lifx api has quite a few options but I dont want this to turn into a config hell.

I had fun playing around with this, let me know if this is something you would include?

Thanks